### PR TITLE
feat(zsh): add gscopy for commit prompts

### DIFF
--- a/macOS-Library/Library/Application Support/Code/User/settings.json
+++ b/macOS-Library/Library/Application Support/Code/User/settings.json
@@ -139,12 +139,6 @@
         "vscode-kubernetes.helm-path-mac": "/Users/andreaventi/.vs-kubernetes/tools/helm/darwin-arm64/helm",
         "vscode-kubernetes.minikube-path-mac": "/Users/andreaventi/.vs-kubernetes/tools/minikube/darwin-arm64/minikube"
     },
-    "github.copilot.enable": {
-        "*": false,
-        "plaintext": false,
-        "markdown": false,
-        "scminput": false
-    },
     "[dart]": {
         "editor.formatOnSave": true,
         "editor.formatOnType": true,
@@ -171,5 +165,6 @@
     ],
     "latex-workshop.formatting.latex": "latexindent",
     "editor.largeFileOptimizations": false,
+    "github.copilot.nextEditSuggestions.enabled": true,
 
 }


### PR DESCRIPTION
Introduce a `gscopy` function to generate Conventional Commit templates with context-aware details. Replaces the old alias, adds diff/branch awareness, and copies a ready-to-use prompt.

- Computes file/insert/delete stats and current branch
- Suggests and formats professional branch names when warranted
- Minor VS Code prefs tweak: enable Copilot next-edit suggestions