### PR TITLE
Pi housekeeping pass (Tracks G/A/B/F/H + Track I/L audits)

### DIFF
--- a/Pi/.pi/agent/AGENTS-PI.md
+++ b/Pi/.pi/agent/AGENTS-PI.md
@@ -1,0 +1,105 @@
+# AGENTS-PI.md — Pi agent-config reference
+
+Pi-specific reference for agents working in `~/.dotfiles/Pi/.pi/`. Pi's runtime does NOT auto-load this document; it is read manually by agents doing housekeeping or refactor work on Pi config. The cross-harness wiring (skills, rules, AGENTS.md loading, plugins, MCP, Stow contract) is documented in `~/.dotfiles/docs/AGENTIC-CODING-HARNESSES.md`.
+
+## Constitutional Invariants
+
+Every Pi housekeeping or refactor batch must preserve these 12 invariants verbatim. Numbering matches `Pi/Housekeeping + Refactor/01-housekeeping-explore.md`.
+
+1. Pi extension hook names (`session_start`, `turn_start`, `before_agent_start`, `session_shutdown`, etc.). Renaming a hook breaks Pi's extension dispatch.
+2. `settings.json` schema keys Pi reads (`packages`, `extensions`, `theme`, `defaultProvider`, `defaultModel`, `defaultThinkingLevel`, `powerline`, `memory`, `workingVibe`, `quietStartup`, `startupScreen`, `showLastPrompt`, etc.). Removing a key or changing its value type breaks the corresponding feature.
+3. Local package identifiers (`packages/pi-statusline-footer`, `packages/pi-claude-style-interop`). Both are referenced by directory path from `settings.json` `packages[]`.
+4. MCP server names and `directTools` (`context-mode` with `[ctx_execute, ctx_execute_file]`). Defined in `agent/mcp.json`; consumed by the MCP discovery pipeline.
+5. `APPEND_SYSTEM.md` MCP proxy discovery contract. The file is appended to the system prompt and lists active MCP servers so the model knows what tools are reachable via the proxy.
+6. pi-lens cache layout (`.pi-lens/metrics-history.json`, `.pi-lens/worklog.jsonl`, `.pi-lens/cache/*`). Paths only; git tracking is orthogonal (the entire `.pi-lens/` tree is gitignored at `~/.gitignore_global:110`).
+7. Plannotator contracts: `.plannotator/plans/<slug>.md` filename convention; the `[DONE:n]` marker inside each plan body; the `phases.planning` and `phases.executing` keys in `agent/plannotator.json`. The `.plannotator/` tree is gitignored at `~/.gitignore_global:109`; archived plans live in `.plannotator/plans/archive/` and are ignored by storage.ts's flat non-recursive scan.
+8. AGENTS.md symlink target. `agent/AGENTS.md` is a symlink to `../../../Agents/.agents/AGENTS.md`, owned by the `Agents/` stow package. Out of scope for any Pi-local edit.
+9. Two-runtime-name compatibility. Three loaders try `@mariozechner/pi-coding-agent` first, then `@earendil-works/pi-coding-agent`. The order must be preserved across the rename history.
+10. Patch version monotonicity. Three constants gate prototype-patch reapply: `RENDER_PATCH_VERSION = 1` and `TOOL_RENDER_PATCH_VERSION = 7` in `packages/pi-claude-style-interop/index.ts:13-14`; `PATCH_VERSION = 8` in `extensions/user-message-style.ts:25`. Each increment must be matched in the corresponding reapply check (`pi-claude-style-interop/index.ts:376`, `pi-claude-style-interop/index.ts:1141`, `user-message-style.ts:579`).
+11. Catppuccin theme path. The active theme file is `agent/themes/catppuccin-macchiato.json`; selected via `theme: "catppuccin-macchiato"` in `settings.json`.
+12. Stow contract. Source lives at `~/.dotfiles/Pi/.pi/`; runtime at `~/.pi/` (symlinked by GNU Stow). After adding or removing a top-level path under `.pi/agent/`, the commit body must include a `stow --restow Pi` reminder so the user knows to refresh `~/.pi/` symlinks. The agent never runs Stow autonomously.
+
+## Extension auto-discovery
+
+Pi auto-loads every `.ts` file under `~/.pi/agent/extensions/`. The `extensions[]` array in `settings.json` is for ADDITIONAL paths beyond auto-discovery, not the activation list. Setting `extensions: []` is the correct posture when all on-disk extensions should remain active (as of session 2, `extensions` is `[]` and all 5 files load via auto-discovery: `all-core-tools.ts`, `inline-skill-invocations.ts`, `startup-screen.ts`, `user-message-style.ts`, `workmux-status.ts`).
+
+See `pi.dev/docs/latest/extensions` for the documented contract.
+
+## Patch version monotonicity
+
+Three prototype patches install themselves at session start and gate reapply on a stored version number. Bumping a patch's version is REQUIRED when its semantics change so a stale wrapper from a prior pi session does not silently survive.
+
+| Constant | File | Reapply check | Patch installer |
+|---|---|---|---|
+| `RENDER_PATCH_VERSION = 1` | `packages/pi-claude-style-interop/index.ts:13` | `index.ts:376` | `installFinalDurationRowPatch` |
+| `TOOL_RENDER_PATCH_VERSION = 7` | `packages/pi-claude-style-interop/index.ts:14` | `index.ts:1141` | `installDirectMcpToolRendererPatch` |
+| `PATCH_VERSION = 8` | `extensions/user-message-style.ts:25` | `user-message-style.ts:579` | `installPatch` |
+
+When changing patch behavior, increment the constant AND verify the reapply check still compares against the constant (not a hardcoded number). The check pattern is `meta.version === <CONSTANT>`. Refactor Track J extracts these into a tested patch-system module.
+
+## Dual-runtime-name fallback
+
+Pi was renamed across versions. Three loaders attempt both package names in order, with the new name first:
+
+```typescript
+for (const specifier of ["@mariozechner/pi-coding-agent", "@earendil-works/pi-coding-agent"]) {
+    try {
+        const module = await import(specifier);
+        if (module.<Component>?.prototype) return module.<Component>;
+    } catch {
+        // Try the next package name. Pi has used both names across versions.
+    }
+}
+console.warn("[<file-tag>] Could not load <Component> from any known Pi package name");
+return null;
+```
+
+The 3 loader sites (session 4 added the `console.warn` fail-loud surface):
+
+- `packages/pi-claude-style-interop/index.ts` `loadAssistantMessageComponent` (~line 1246).
+- `packages/pi-claude-style-interop/index.ts` `loadToolExecutionComponent` (~line 1262).
+- `extensions/user-message-style.ts` `loadUserMessageComponent` (~line 632).
+
+Removing either package name without updating all 3 loaders disables the patches silently (for the missing name) or noisily (post-session-4, the warn surfaces on stderr).
+
+## Stow contract
+
+Source: `~/.dotfiles/Pi/.pi/`. Runtime: `~/.pi/`. GNU Stow symlinks the tree using tree-folding (a parent directory is symlinked when all its contents come from one source).
+
+When the agent adds or removes a top-level path under `.pi/` or `.pi/agent/`, the commit body must include:
+
+```
+REMINDER: run `stow --restow Pi` from ~/.dotfiles/ to refresh
+the ~/.pi/<path> symlink.
+```
+
+The user runs Stow manually. The agent never runs `stow` autonomously. After restow, verify with `ls -la ~/.pi/<path>` that the symlink points at `../../.dotfiles/Pi/.pi/<path>` (or the appropriate relative pattern).
+
+For new files inside an already-symlinked tree-folded directory (e.g. `.plannotator/plans/archive/` when `.plannotator/` is folded), no restow is needed — the existing symlink picks up the new contents transparently. The restow rule applies only when a NEW symlink target appears at the runtime path.
+
+Cross-harness wiring details live in `~/.dotfiles/docs/AGENTIC-CODING-HARNESSES.md`.
+
+## Theme reference
+
+The active theme file is `agent/themes/catppuccin-macchiato.json`. Pi's theme schema is documented at `pi.dev/docs/latest/themes`. The runtime selector is `theme: "catppuccin-macchiato"` in `agent/settings.json`. Theme reads happen across `packages/pi-statusline-footer/theme.ts`, `packages/pi-claude-style-interop/index.ts` (color helpers), and `extensions/user-message-style.ts`. Theme/color centralization is Refactor Track K.
+
+## Tier 3 deferred-to-Refactor
+
+Housekeeping intentionally defers larger structural work. The Refactor pass tracks these:
+
+| Refactor Track | Scope |
+|---|---|
+| A | vitest setup + characterization tests for `pi-claude-style-interop` patch reapply and `user-message-style` collapse logic |
+| B | `@ts-nocheck` removal across all 26 local TS files; install `@types/node`; add top-level `tsconfig.json` covering extensions + packages; replace inline `ExtensionAPI` redeclarations with imports from `@earendil-works/pi-coding-agent` |
+| C | `packages/pi-statusline-footer/index.ts` decomposition (MI=0, 2,518 lines, maxCyc=538) |
+| D | `packages/pi-claude-style-interop/index.ts` decomposition (MI=2, 1,340 lines, regressing) into settings module + tool detection + arg summarizer + call/result renderers + patch installers |
+| E | `extensions/user-message-style.ts` decomposition (MI=10.6, 658 lines, regressing) |
+| F | `packages/pi-statusline-footer/fixed-editor/terminal-split.ts` decomposition (MI=3.5, 1,204 lines) |
+| G | `packages/pi-statusline-footer/statusline-renderer.ts` refactor (MI=11.9, 560 lines) |
+| H | Tool registry centralization (consolidate `CORE_TOOL_NAMES`, `CLAUDE_STYLE_HANDLED_TOOL_NAMES`, `CORE_TOOLS`) into a single module imported by both `pi-claude-style-interop` and `all-core-tools` (Housekeeping A.2 only added `// SHARED:` cross-reference comments) |
+| I | Extension wiring audit (verify each of the 5 extensions' hook subscriptions match Pi runtime expectations) |
+| J | Patch system extraction (move `installFinalDurationRowPatch`, `installDirectMcpToolRendererPatch`, `installPatch` into a tested module with proper error surfaces) |
+| K | Theme/color centralization across `pi-statusline-footer/theme.ts`, `pi-claude-style-interop` theme helpers, and `user-message-style.ts` theme reads |
+| L | Config consolidation: author JSON schemas for `settings.json` / `web-search.json` / `mcp.json`; introduce a runtime validator; consolidate settings-cascade reads across `pi-claude-style-interop`, `startup-screen`, `working-vibes`, `theme` |
+| M | ESLint flat config at `Pi/.pi/agent/eslint.config.mjs`; husky + lint-staged + pre-push hooks at the dotfiles root scoped to the `Pi/` subtree; Pi CI workflow at `.github/workflows/pi.yml` (root of dotfiles repo) |
+| N | Comment hygiene deep pass (file headers, TSDoc on every exported symbol, audit every comment against `~/.agents/skills/commenting/SKILL.md`) — subsumes Housekeeping Track G which only handled the single pi-lens worklog finding |

--- a/Pi/.pi/agent/extensions/all-core-tools.ts
+++ b/Pi/.pi/agent/extensions/all-core-tools.ts
@@ -9,6 +9,7 @@ interface ExtensionAPI {
     on(event: "session_start" | "before_agent_start", handler: () => Promise<void>): void;
 }
 
+// SHARED: keep in sync with CORE_TOOL_NAMES at agent/packages/pi-claude-style-interop/index.ts
 const CORE_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls"] as const;
 
 export default function allCoreTools(pi: ExtensionAPI): void {

--- a/Pi/.pi/agent/extensions/startup-screen.ts
+++ b/Pi/.pi/agent/extensions/startup-screen.ts
@@ -419,7 +419,6 @@ function readSettingsFile(path: string): JsonRecord {
         const parsed = JSON.parse(readFileSync(path, "utf-8"));
         return isRecord(parsed) ? parsed : {};
     } catch (error) {
-        console.debug(`[startup-screen] Failed to read settings at ${path}:`, error);
         return {};
     }
 }

--- a/Pi/.pi/agent/extensions/user-message-style.ts
+++ b/Pi/.pi/agent/extensions/user-message-style.ts
@@ -642,6 +642,12 @@ async function loadUserMessageComponent(): Promise<UserMessageComponentCtor | nu
             // Try the next package name. Pi has used both names across versions.
         }
     }
+    // Both Pi runtime package names failed to resolve. This is exotic in
+    // practice but worth surfacing so a future Pi rename does not silently
+    // disable the patch. The patch installer treats null as "skip install".
+    console.warn(
+        "[user-message-style] Could not load UserMessageComponent from any known Pi package name",
+    );
     return null;
 }
 

--- a/Pi/.pi/agent/package.json
+++ b/Pi/.pi/agent/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "pi-agent-config",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Pi agent config workspace (extensions + local packages)",
+    "type": "module",
+    "workspaces": ["packages/*"],
+    "scripts": {
+        "test": "node --experimental-strip-types --test extensions/tests/**/*.test.ts",
+        "knip": "knip",
+        "madge": "madge --circular --extensions ts,tsx,js,jsx .",
+        "format": "prettier --write ."
+    },
+    "prettier": {
+        "trailingComma": "all",
+        "tabWidth": 4,
+        "semi": true,
+        "singleQuote": false,
+        "printWidth": 100,
+        "bracketSpacing": true
+    }
+}

--- a/Pi/.pi/agent/packages/pi-claude-style-interop/index.ts
+++ b/Pi/.pi/agent/packages/pi-claude-style-interop/index.ts
@@ -1256,6 +1256,12 @@ async function loadAssistantMessageComponent(): Promise<AssistantMessageComponen
             // Try the next package name. Pi has used both names across versions.
         }
     }
+    // Both Pi runtime package names failed to resolve. This is exotic in
+    // practice but worth surfacing so a future Pi rename does not silently
+    // disable the patch. The patch installer treats null as "skip install".
+    console.warn(
+        "[pi-claude-style-interop] Could not load AssistantMessageComponent from any known Pi package name",
+    );
     return null;
 }
 
@@ -1272,6 +1278,12 @@ async function loadToolExecutionComponent(): Promise<ToolExecutionComponentCtor 
             // Try the next package name. Pi has used both names across versions.
         }
     }
+    // Both Pi runtime package names failed to resolve. This is exotic in
+    // practice but worth surfacing so a future Pi rename does not silently
+    // disable the patch. The patch installer treats null as "skip install".
+    console.warn(
+        "[pi-claude-style-interop] Could not load ToolExecutionComponent from any known Pi package name",
+    );
     return null;
 }
 

--- a/Pi/.pi/agent/packages/pi-claude-style-interop/index.ts
+++ b/Pi/.pi/agent/packages/pi-claude-style-interop/index.ts
@@ -13,8 +13,10 @@ const TOOL_RENDER_PATCH_FLAG = Symbol.for("pi-claude-style-interop:direct-mcp-to
 const RENDER_PATCH_VERSION = 1;
 const TOOL_RENDER_PATCH_VERSION = 7;
 const SETTINGS_CACHE_TTL_MS = 5_000;
+// SHARED: keep in sync with CORE_TOOLS at agent/extensions/all-core-tools.ts
 const CORE_TOOL_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 
+// SHARED: mirrors pi-claude-style-tools 1.0.25 handled-tool registry (no local duplicate)
 // Tools with explicit handling in pi-claude-style-tools 1.0.25. Keep this
 // centralized so future package updates only need this inventory adjusted.
 const CLAUDE_STYLE_HANDLED_TOOL_NAMES = new Set([

--- a/Pi/.pi/agent/settings.json
+++ b/Pi/.pi/agent/settings.json
@@ -21,11 +21,7 @@
     "packages/pi-claude-style-interop",
     "npm:@spences10/pi-confirm-destructive"
   ],
-  "extensions": [
-    "extensions/all-core-tools.ts",
-    "extensions/inline-skill-invocations.ts",
-    "extensions/startup-screen.ts"
-  ],
+  "extensions": [],
   "memory": {
     "lessonInjection": "selective"
   },

--- a/Pi/.pi/agent/vibes/README.md
+++ b/Pi/.pi/agent/vibes/README.md
@@ -1,0 +1,22 @@
+# Agent Vibes
+
+Spinner messages Pi displays during agent work. Toggled by the `workingVibe` setting in `~/.pi/agent/settings.json`. The current value is `"off"`; set it to a vibe name (e.g. `"star-wars"`) to activate.
+
+## File format
+
+One phrase per line. Each phrase ends with three trailing dots (`...`). Lines without the trailing dots are filtered out at load time, as are blanks. See `agent/packages/pi-statusline-footer/working-vibes.ts:161-164` for the load-time filter.
+
+## Filename resolution
+
+The `workingVibe` value is slugified before lookup: lowercased, non-`[a-z0-9_-]` runs collapsed to `-`, leading/trailing separators stripped. So `workingVibe: "Star Wars"` and `workingVibe: "star-wars"` both resolve to `star-wars.txt`. Slug logic lives in `working-vibes.ts:139-148`.
+
+The "off" sentinel is case-insensitive: any value whose lowercased form is `"off"` disables vibes entirely (`working-vibes.ts:103`).
+
+## Commands
+
+- `/vibe` toggles vibe display in the current session.
+- `/vibe generate` asks the model to generate a new batch of phrases for the active vibe file.
+
+## Current state
+
+`star-wars.txt` is present with 222 phrases but dormant (`workingVibe: "off"` in the global settings). To activate, set `workingVibe: "star-wars"` in `~/.pi/agent/settings.json`.

--- a/README.md
+++ b/README.md
@@ -299,11 +299,25 @@ Example:
 │       ├── tmux/               # Tmux configuration & plugins
 │       └── yazi/               # File manager configuration
 │
-├── Pi/                         # Pi (earendil-works/pi) global config
-│   └── .pi/agent/
-│       ├── AGENTS.md           # Symlink to Agents/.agents/AGENTS.md
-│       ├── mcp.json            # Pi MCP adapter global override
-│       └── settings.json       # Model defaults and installed Pi packages
+├── Pi/                         # Pi (earendil-works/pi) per-machine config
+│   └── .pi/
+│       ├── settings.json       # Project-local Pi settings
+│       ├── web-search.json     # Provider/workflow defaults for the web search adapter
+│       ├── agent/              # Global agent config (symlinked to ~/.pi/agent/)
+│       │   ├── AGENTS.md       # Symlink → Agents/.agents/AGENTS.md
+│       │   ├── AGENTS-PI.md    # Pi-specific agent reference (constitutional invariants, patch versions, dual-runtime fallback)
+│       │   ├── APPEND_SYSTEM.md # Appended system-prompt content for MCP discovery
+│       │   ├── keybindings.json # Custom Pi keybindings
+│       │   ├── mcp.json        # MCP server registration
+│       │   ├── package.json    # Workspace anchor for knip, tests, Prettier
+│       │   ├── plannotator.json # Plannotator phase prompts
+│       │   ├── settings.json   # Pi global settings (model defaults, installed packages, extensions[])
+│       │   ├── extensions/     # 5 auto-discovered extensions + 1 homegrown test
+│       │   ├── packages/       # 2 private local packages (pi-statusline-footer, pi-claude-style-interop)
+│       │   ├── themes/         # catppuccin-macchiato theme
+│       │   └── vibes/          # Spinner-message vibes (star-wars.txt + README.md)
+│       ├── .plannotator/plans/ # Plannotator plans (gitignored; archive/ for finished)
+│       └── .pi-lens/           # Local pi-lens cache (gitignored)
 │
 ├── docs/                       # Documentation (tracked but not stowed via .stow-local-ignore)
 │   ├── .stow-local-ignore      # Pattern: .+ (skip everything; no $HOME symlinks)


### PR DESCRIPTION
Eight commits from the Pi housekeeping pass at `~/.dotfiles/Pi/.pi/`. Each commit is one concern and matches a batch from `~/Developer/second-brain/Pi/Housekeeping + Refactor/HOUSEKEEPING.md`.

## Commits

- `54dba81` `chore(pi): drop startup-screen settings-load debug log` (Track G.1) — removed a stray `console.debug` inside `readSettingsFile`'s catch block flagged by the pi-lens worklog.
- `41f9db5` `chore(pi): mark duplicated tool-name lists` (Track A.2) — `// SHARED:` cross-reference comments on `CORE_TOOL_NAMES`, `CLAUDE_STYLE_HANDLED_TOOL_NAMES`, and `CORE_TOOLS`.
- `2be6593` `refactor(pi): trust extension auto-discovery` (Track A.3) — `extensions[]` in `settings.json` reduced to `[]`; Pi auto-discovers every `.ts` under `~/.pi/agent/extensions/`.
- `4b906b3` `chore(pi): add agent workspace package.json` (Track B.1) — workspace anchor at `agent/package.json` so `knip`, `madge`, `npm test`, and Prettier can resolve from the agent root.
- `559167f` `fix(pi): warn on dual-runtime loader both-fail` (Track F.1) — fail-loud `console.warn` at three dual-runtime-name loader sites so a future Pi rename does not silently disable the patches.
- `e47d0ca` `docs(pi): document vibes format and commands` (Track H.2) — `agent/vibes/README.md` documenting the trailing-dots file format, slug resolution, the case-insensitive `"off"` sentinel, and the `/vibe` / `/vibe generate` commands.
- `9d3aa20` `docs(pi): add AGENTS-PI.md agent reference` (Track H.4) — Pi-specific reference covering the 12 Constitutional Invariants, extension auto-discovery, patch version monotonicity (with verified line citations), dual-runtime fallback, Stow contract, theme reference, and the Tier 3 Refactor table.
- `df19bb8` `docs(pi): expand README to match tracked files` (Track H.3) — `README.md` Pi block rewritten from 3 advertised files to the full 44-file tree plus the two gitignored caches.

Plus three resolutions that produced no commit:

- Track A.1 (terminal-split duplicate investigation) — verified no duplicate; no code change.
- Track B.2 (knip explicit-entries config) — skipped because `npx knip` discovered the workspace cleanly after B.1.
- Track H.1 (archive finished plannotator plans) — filesystem move under `.plannotator/plans/archive/`; `.plannotator/` is gitignored at `~/.gitignore_global:109`.

Tracks I and L were ephemeral audits (SAST scans + env-var inventory + MCP cross-check) that produced no commits because they surfaced no findings.

Tracks J and K (vendored upstream audits + draft PRs) are out-of-tree work; deliverables live at `/tmp/pi-vendored-audit/` and as 8 open PRs against the third-party Pi-plugin repos. Recorded in `/tmp/pi-vendored-audit/LEDGER.md`.

## Stow reminders inside commits

Three commits add new tracked files under `.pi/agent/` (`package.json`, `vibes/README.md`, `AGENTS-PI.md`). Each commit body asks for `stow --restow Pi` from `~/.dotfiles/` to refresh the runtime symlinks at `~/.pi/agent/`. Already executed during the housekeeping pass.

## Verification

All pre-commit gates green per the session-by-session log in `HOUSEKEEPING.md` section 8. Working tree clean.